### PR TITLE
Add teacher home dashboard interface

### DIFF
--- a/lib/features/teacher_home/models.dart
+++ b/lib/features/teacher_home/models.dart
@@ -1,0 +1,205 @@
+import 'package:flutter/material.dart';
+
+class TeacherOverviewStat {
+  const TeacherOverviewStat({
+    required this.label,
+    required this.value,
+    required this.icon,
+    required this.color,
+  });
+
+  final String label;
+  final String value;
+  final IconData icon;
+  final Color color;
+}
+
+class QuickActionItem {
+  const QuickActionItem({
+    required this.title,
+    required this.description,
+    required this.icon,
+    required this.color,
+    this.onTap,
+  });
+
+  final String title;
+  final String description;
+  final IconData icon;
+  final Color color;
+  final VoidCallback? onTap;
+}
+
+class TeacherClassSession {
+  const TeacherClassSession({
+    required this.courseName,
+    required this.level,
+    required this.time,
+    required this.room,
+    required this.status,
+    this.students,
+  });
+
+  final String courseName;
+  final String level;
+  final String time;
+  final String room;
+  final String status;
+  final int? students;
+}
+
+class UpcomingTask {
+  const UpcomingTask({
+    required this.title,
+    required this.dueDate,
+    required this.note,
+    required this.color,
+  });
+
+  final String title;
+  final String dueDate;
+  final String note;
+  final Color color;
+}
+
+class RecentActivity {
+  const RecentActivity({
+    required this.content,
+    required this.timeAgo,
+    required this.icon,
+    required this.color,
+  });
+
+  final String content;
+  final String timeAgo;
+  final IconData icon;
+  final Color color;
+}
+
+class TeacherHomeData {
+  TeacherHomeData()
+      : overviewStats = const [
+          TeacherOverviewStat(
+            label: 'Lớp đang dạy',
+            value: '3',
+            icon: Icons.class_,
+            color: Color(0xFF4F46E5),
+          ),
+          TeacherOverviewStat(
+            label: 'Học viên phụ trách',
+            value: '42',
+            icon: Icons.people_alt_rounded,
+            color: Color(0xFF16A34A),
+          ),
+          TeacherOverviewStat(
+            label: 'Tỷ lệ đánh giá',
+            value: '4.8',
+            icon: Icons.star_rounded,
+            color: Color(0xFFF97316),
+          ),
+        ],
+        quickActions = [
+          QuickActionItem(
+            title: 'Lớp học của tôi',
+            description: 'Quản lý và cập nhật tiến độ lớp',
+            icon: Icons.menu_book_rounded,
+            color: const Color(0xFF6366F1),
+          ),
+          QuickActionItem(
+            title: 'Học viên',
+            description: 'Theo dõi tình trạng từng học viên',
+            icon: Icons.group_rounded,
+            color: const Color(0xFF0EA5E9),
+          ),
+          QuickActionItem(
+            title: 'Điểm danh',
+            description: 'Ghi nhận chuyên cần theo buổi',
+            icon: Icons.fact_check_rounded,
+            color: const Color(0xFFF59E0B),
+          ),
+          QuickActionItem(
+            title: 'Lịch giảng dạy',
+            description: 'Xem toàn bộ lịch dạy trong tuần',
+            icon: Icons.calendar_month_rounded,
+            color: const Color(0xFF10B981),
+          ),
+        ],
+        todayClasses = const [
+          TeacherClassSession(
+            courseName: 'Tiếng Anh Doanh Nghiệp',
+            level: 'Nhóm B',
+            time: '09:00 - 10:30',
+            room: 'Phòng 201',
+            status: 'sắp diễn ra',
+            students: 12,
+          ),
+          TeacherClassSession(
+            courseName: 'IELTS Chiến Lược',
+            level: 'Nhóm A',
+            time: '13:30 - 15:30',
+            room: 'Phòng 305',
+            status: 'đang học',
+            students: 16,
+          ),
+          TeacherClassSession(
+            courseName: 'Giao Tiếp Chuyên Nghiệp',
+            level: 'Cấp độ Trung Cấp',
+            time: '18:00 - 19:30',
+            room: 'Studio 02',
+            status: 'chuẩn bị',
+            students: 10,
+          ),
+        ],
+        upcomingTasks = const [
+          UpcomingTask(
+            title: 'Chuẩn bị giáo án cho lớp Doanh nghiệp',
+            dueDate: 'Hạn: hôm nay - 15:30',
+            note: 'Hoàn thiện slide và bài tập thực hành',
+            color: Color(0xFF6366F1),
+          ),
+          UpcomingTask(
+            title: 'Chấm bài tập IELTS - Nhóm A',
+            dueDate: 'Hạn: ngày mai',
+            note: 'Cần phản hồi chi tiết cho từng học viên',
+            color: Color(0xFFF97316),
+          ),
+          UpcomingTask(
+            title: 'Cập nhật báo cáo chuyên cần tuần 6',
+            dueDate: 'Hạn: Thứ Sáu',
+            note: 'Đối chiếu với ngưỡng điểm danh lớp',
+            color: Color(0xFF0EA5E9),
+          ),
+        ],
+        recentActivities = const [
+          RecentActivity(
+            content: '12 học viên hoàn thành bài tập Unit 3',
+            timeAgo: '30 phút trước',
+            icon: Icons.assignment_turned_in_rounded,
+            color: Color(0xFF6366F1),
+          ),
+          RecentActivity(
+            content: 'Nguyễn Minh Anh được nâng cấp độ Intermediate',
+            timeAgo: '2 giờ trước',
+            icon: Icons.trending_up_rounded,
+            color: Color(0xFF10B981),
+          ),
+          RecentActivity(
+            content: 'Điểm danh lớp IELTS Nhóm A đã hoàn tất',
+            timeAgo: 'Hôm qua',
+            icon: Icons.fact_check_rounded,
+            color: Color(0xFFF59E0B),
+          ),
+          RecentActivity(
+            content: 'Phản hồi mới từ học viên: 4.9/5',
+            timeAgo: '2 ngày trước',
+            icon: Icons.feedback_rounded,
+            color: Color(0xFF0EA5E9),
+          ),
+        ];
+
+  final List<TeacherOverviewStat> overviewStats;
+  final List<QuickActionItem> quickActions;
+  final List<TeacherClassSession> todayClasses;
+  final List<UpcomingTask> upcomingTasks;
+  final List<RecentActivity> recentActivities;
+}

--- a/lib/features/teacher_home/teacher_home_screen.dart
+++ b/lib/features/teacher_home/teacher_home_screen.dart
@@ -1,0 +1,335 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import 'models.dart';
+import 'widgets/overview_stat_card.dart';
+import 'widgets/quick_action_card.dart';
+import 'widgets/recent_activity_tile.dart';
+import 'widgets/task_card.dart';
+import 'widgets/today_class_card.dart';
+
+class TeacherHomeScreen extends StatelessWidget {
+  const TeacherHomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final data = TeacherHomeData();
+    final now = DateTime.now();
+    final greeting = _greetingMessage(now.hour);
+    final dateText = DateFormat('EEEE, dd/MM/yyyy', 'vi_VN').format(now);
+
+    return Scaffold(
+      backgroundColor: const Color(0xFFF9FAFB),
+      body: CustomScrollView(
+        slivers: [
+          SliverAppBar(
+            backgroundColor: Colors.white,
+            expandedHeight: 140,
+            floating: false,
+            pinned: true,
+            elevation: 0,
+            flexibleSpace: FlexibleSpaceBar(
+              background: Container(
+                padding: const EdgeInsets.only(top: 48, left: 24, right: 24, bottom: 24),
+                decoration: const BoxDecoration(
+                  gradient: LinearGradient(
+                    colors: [Color(0xFF4F46E5), Color(0xFF6366F1)],
+                    begin: Alignment.topLeft,
+                    end: Alignment.bottomRight,
+                  ),
+                  borderRadius: BorderRadius.only(
+                    bottomLeft: Radius.circular(36),
+                    bottomRight: Radius.circular(36),
+                  ),
+                ),
+                child: SafeArea(
+                  bottom: false,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          CircleAvatar(
+                            radius: 26,
+                            backgroundColor: Colors.white.withOpacity(0.2),
+                            child: const Text(
+                              'EC',
+                              style: TextStyle(
+                                color: Colors.white,
+                                fontSize: 20,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                          Row(
+                            children: [
+                              IconButton(
+                                onPressed: () {},
+                                icon: const Icon(Icons.notifications_none_rounded, color: Colors.white),
+                              ),
+                              IconButton(
+                                onPressed: () {},
+                                icon: const Icon(Icons.settings_outlined, color: Colors.white),
+                              ),
+                            ],
+                          )
+                        ],
+                      ),
+                      const SizedBox(height: 24),
+                      Text(
+                        '$greeting, Emily',
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 24,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        'Sẵn sàng cho lớp học hôm nay chứ?',
+                        style: TextStyle(
+                          color: Colors.white.withOpacity(0.85),
+                          fontSize: 16,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+            bottom: PreferredSize(
+              preferredSize: const Size.fromHeight(70),
+              child: Container(
+                transform: Matrix4.translationValues(0, 24, 0),
+                padding: const EdgeInsets.symmetric(horizontal: 24),
+                child: Material(
+                  elevation: 6,
+                  borderRadius: BorderRadius.circular(24),
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+                    decoration: BoxDecoration(
+                      color: Colors.white,
+                      borderRadius: BorderRadius.circular(24),
+                    ),
+                    child: Row(
+                      children: [
+                        const Icon(Icons.calendar_today_rounded, color: Color(0xFF6366F1)),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: Text(
+                            dateText,
+                            style: const TextStyle(
+                              color: Color(0xFF1F2937),
+                              fontWeight: FontWeight.w600,
+                              fontSize: 16,
+                            ),
+                          ),
+                        ),
+                        Container(
+                          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                          decoration: BoxDecoration(
+                            color: const Color(0xFFE0E7FF),
+                            borderRadius: BorderRadius.circular(20),
+                          ),
+                          child: const Text(
+                            '3 lớp hôm nay',
+                            style: TextStyle(
+                              color: Color(0xFF4338CA),
+                              fontWeight: FontWeight.w700,
+                            ),
+                          ),
+                        )
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+          SliverPadding(
+            padding: const EdgeInsets.fromLTRB(24, 48, 24, 24),
+            sliver: SliverList.list(
+              children: [
+                Text(
+                  'Tổng quan nhanh',
+                  style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                        color: const Color(0xFF111827),
+                        fontWeight: FontWeight.w800,
+                      ),
+                ),
+                const SizedBox(height: 16),
+                GridView.builder(
+                  shrinkWrap: true,
+                  physics: const NeverScrollableScrollPhysics(),
+                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: 2,
+                    childAspectRatio: 1.8,
+                    crossAxisSpacing: 16,
+                    mainAxisSpacing: 16,
+                  ),
+                  itemCount: data.overviewStats.length,
+                  itemBuilder: (context, index) => OverviewStatCard(stat: data.overviewStats[index]),
+                ),
+                const SizedBox(height: 28),
+                Text(
+                  'Tác vụ nhanh',
+                  style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                        color: const Color(0xFF111827),
+                        fontWeight: FontWeight.w800,
+                      ),
+                ),
+                const SizedBox(height: 16),
+                GridView.builder(
+                  shrinkWrap: true,
+                  physics: const NeverScrollableScrollPhysics(),
+                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: 2,
+                    crossAxisSpacing: 16,
+                    mainAxisSpacing: 16,
+                    childAspectRatio: 0.95,
+                  ),
+                  itemCount: data.quickActions.length,
+                  itemBuilder: (context, index) => QuickActionCard(action: data.quickActions[index]),
+                ),
+                const SizedBox(height: 28),
+                _SectionHeader(
+                  title: 'Lớp học trong ngày',
+                  actionLabel: 'Xem lịch',
+                  onTap: () {},
+                ),
+                const SizedBox(height: 12),
+                ...data.todayClasses.map((session) => TodayClassCard(session: session)),
+                const SizedBox(height: 28),
+                _SectionHeader(
+                  title: 'Công việc sắp tới',
+                  actionLabel: 'Xem tất cả',
+                  onTap: () {},
+                ),
+                const SizedBox(height: 12),
+                ...data.upcomingTasks.map((task) => UpcomingTaskCard(task: task)),
+                const SizedBox(height: 28),
+                _SectionHeader(
+                  title: 'Hoạt động gần đây',
+                  actionLabel: 'Chi tiết',
+                  onTap: () {},
+                ),
+                const SizedBox(height: 12),
+                ...data.recentActivities.map((activity) => RecentActivityTile(activity: activity)),
+                const SizedBox(height: 32),
+                _FeedbackBanner(),
+              ],
+            ),
+          )
+        ],
+      ),
+    );
+  }
+
+  String _greetingMessage(int hour) {
+    if (hour < 11) return 'Chào buổi sáng';
+    if (hour < 18) return 'Chào buổi chiều';
+    return 'Chào buổi tối';
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader({
+    required this.title,
+    required this.actionLabel,
+    this.onTap,
+  });
+
+  final String title;
+  final String actionLabel;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text(
+          title,
+          style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                color: const Color(0xFF111827),
+                fontWeight: FontWeight.w800,
+              ),
+        ),
+        TextButton(
+          onPressed: onTap,
+          style: TextButton.styleFrom(
+            foregroundColor: const Color(0xFF6366F1),
+            textStyle: const TextStyle(fontWeight: FontWeight.w700),
+          ),
+          child: Text(actionLabel),
+        ),
+      ],
+    );
+  }
+}
+
+class _FeedbackBanner extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        gradient: const LinearGradient(
+          colors: [Color(0xFF1E293B), Color(0xFF334155)],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+        borderRadius: BorderRadius.circular(24),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: Colors.white.withOpacity(0.15),
+              borderRadius: BorderRadius.circular(16),
+            ),
+            child: const Icon(Icons.headset_mic_rounded, color: Colors.white, size: 28),
+          ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Cần hỗ trợ từ học vụ?',
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        color: Colors.white,
+                        fontWeight: FontWeight.w700,
+                      ),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  'Liên hệ bộ phận hỗ trợ để được cập nhật tài liệu, phân bổ lớp mới hoặc điều chỉnh lịch dạy.',
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: Colors.white.withOpacity(0.8),
+                        height: 1.5,
+                      ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 12),
+          FilledButton(
+            onPressed: () {},
+            style: FilledButton.styleFrom(
+              backgroundColor: Colors.white,
+              foregroundColor: const Color(0xFF1E293B),
+              padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+            ),
+            child: const Text('Liên hệ ngay'),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/teacher_home/widgets/overview_stat_card.dart
+++ b/lib/features/teacher_home/widgets/overview_stat_card.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+
+import '../models.dart';
+
+class OverviewStatCard extends StatelessWidget {
+  const OverviewStatCard({super.key, required this.stat});
+
+  final TeacherOverviewStat stat;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: stat.color.withOpacity(0.08),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: stat.color.withOpacity(0.25)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Container(
+            height: 44,
+            width: 44,
+            decoration: BoxDecoration(
+              color: stat.color,
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: Icon(stat.icon, color: Colors.white, size: 24),
+          ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  stat.label,
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: const Color(0xFF1F2937),
+                        fontWeight: FontWeight.w600,
+                      ),
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  stat.value,
+                  style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                        color: const Color(0xFF111827),
+                        fontWeight: FontWeight.bold,
+                      ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/teacher_home/widgets/quick_action_card.dart
+++ b/lib/features/teacher_home/widgets/quick_action_card.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+
+import '../models.dart';
+
+class QuickActionCard extends StatelessWidget {
+  const QuickActionCard({super.key, required this.action});
+
+  final QuickActionItem action;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      borderRadius: BorderRadius.circular(20),
+      onTap: action.onTap,
+      child: Ink(
+        decoration: BoxDecoration(
+          color: action.color.withOpacity(0.08),
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: action.color.withOpacity(0.15)),
+        ),
+        padding: const EdgeInsets.all(18),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: action.color,
+                borderRadius: BorderRadius.circular(16),
+              ),
+              child: Icon(action.icon, color: Colors.white, size: 28),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              action.title,
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    color: const Color(0xFF111827),
+                    fontWeight: FontWeight.w700,
+                  ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              action.description,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: const Color(0xFF4B5563),
+                    height: 1.5,
+                  ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/teacher_home/widgets/recent_activity_tile.dart
+++ b/lib/features/teacher_home/widgets/recent_activity_tile.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+
+import '../models.dart';
+
+class RecentActivityTile extends StatelessWidget {
+  const RecentActivityTile({super.key, required this.activity});
+
+  final RecentActivity activity;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.symmetric(vertical: 6),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(18),
+        border: Border.all(color: const Color(0xFFE5E7EB)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: activity.color.withOpacity(0.12),
+              borderRadius: BorderRadius.circular(14),
+            ),
+            child: Icon(activity.icon, color: activity.color, size: 22),
+          ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  activity.content,
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: const Color(0xFF111827),
+                        fontWeight: FontWeight.w600,
+                      ),
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  activity.timeAgo,
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: const Color(0xFF6B7280),
+                      ),
+                ),
+              ],
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/teacher_home/widgets/task_card.dart
+++ b/lib/features/teacher_home/widgets/task_card.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+
+import '../models.dart';
+
+class UpcomingTaskCard extends StatelessWidget {
+  const UpcomingTaskCard({super.key, required this.task});
+
+  final UpcomingTask task;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.symmetric(vertical: 8),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(18),
+        border: Border.all(color: const Color(0xFFE5E7EB)),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.04),
+            blurRadius: 12,
+            offset: const Offset(0, 6),
+          ),
+        ],
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            width: 8,
+            height: 60,
+            decoration: BoxDecoration(
+              color: task.color,
+              borderRadius: BorderRadius.circular(12),
+            ),
+          ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  task.title,
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.w700,
+                        color: const Color(0xFF111827),
+                      ),
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  task.dueDate,
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: task.color,
+                        fontWeight: FontWeight.w600,
+                      ),
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  task.note,
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: const Color(0xFF4B5563),
+                        height: 1.4,
+                      ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 12),
+          Icon(Icons.chevron_right_rounded, color: Colors.grey.shade400),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/teacher_home/widgets/today_class_card.dart
+++ b/lib/features/teacher_home/widgets/today_class_card.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/material.dart';
+
+import '../models.dart';
+
+class TodayClassCard extends StatelessWidget {
+  const TodayClassCard({super.key, required this.session});
+
+  final TeacherClassSession session;
+
+  Color _statusColor(String status) {
+    switch (status) {
+      case 'đang học':
+        return const Color(0xFF0EA5E9);
+      case 'sắp diễn ra':
+        return const Color(0xFFF59E0B);
+      case 'chuẩn bị':
+        return const Color(0xFF6366F1);
+      default:
+        return const Color(0xFF6B7280);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final statusColor = _statusColor(session.status);
+
+    return Container(
+      margin: const EdgeInsets.symmetric(vertical: 8),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(18),
+        border: Border.all(color: const Color(0xFFE5E7EB)),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.04),
+            blurRadius: 12,
+            offset: const Offset(0, 6),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                decoration: BoxDecoration(
+                  color: statusColor.withOpacity(0.12),
+                  borderRadius: BorderRadius.circular(20),
+                ),
+                child: Text(
+                  session.status.toUpperCase(),
+                  style: TextStyle(
+                    color: statusColor,
+                    fontSize: 12,
+                    letterSpacing: 0.5,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+              const Spacer(),
+              Icon(Icons.more_horiz, color: Colors.grey.shade500),
+            ],
+          ),
+          const SizedBox(height: 14),
+          Text(
+            session.courseName,
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w800,
+                  color: const Color(0xFF111827),
+                ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            session.level,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: const Color(0xFF4B5563),
+                  fontWeight: FontWeight.w500,
+                ),
+          ),
+          const SizedBox(height: 16),
+          Row(
+            children: [
+              _InfoChip(icon: Icons.schedule_rounded, label: session.time),
+              const SizedBox(width: 12),
+              _InfoChip(icon: Icons.location_on_rounded, label: session.room),
+              const Spacer(),
+              if (session.students != null)
+                Text(
+                  '${session.students} học viên',
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: const Color(0xFF6B7280),
+                        fontWeight: FontWeight.w600,
+                      ),
+                ),
+            ],
+          )
+        ],
+      ),
+    );
+  }
+}
+
+class _InfoChip extends StatelessWidget {
+  const _InfoChip({required this.icon, required this.label});
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        color: const Color(0xFFF3F4F6),
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: Row(
+        children: [
+          Icon(icon, color: const Color(0xFF4B5563), size: 18),
+          const SizedBox(width: 6),
+          Text(
+            label,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: const Color(0xFF374151),
+                  fontWeight: FontWeight.w600,
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 import 'admin_dashboard/admin_dashboard_screen.dart';
 import 'env.dart';
 import 'features/auth/auth_screen.dart';
+import 'features/teacher_home/teacher_home_screen.dart';
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Supabase.initialize(url: supabaseUrl, anonKey: supabaseAnonKey);
@@ -30,6 +31,7 @@ class MyApp extends StatelessWidget {
         '/': (context) => const LoginScreen(),
         '/login': (context) => const LoginScreen(),
         '/admin': (context) => const AdminDashboardScreen(),
+        '/teacher-home': (context) => const TeacherHomeScreen(),
       },
     );
   }


### PR DESCRIPTION
## Summary
- create teacher home feature module with data models and reusable widget components for overview, quick actions, lớp học, công việc, and hoạt động
- implement giáo viên home screen matching yêu cầu giao diện với tiếng Việt và bổ sung banner hỗ trợ
- expose teacher home route from main application

## Testing
- flutter test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68e2c00a8ee4832a8652967114722033