### PR TITLE
Fix Supabase role mapping and user schema alignment

### DIFF
--- a/lib/features/auth/supabase_auth_service.dart
+++ b/lib/features/auth/supabase_auth_service.dart
@@ -5,36 +5,36 @@ final supa = Supabase.instance.client;
 
 /// Model gọn cho người dùng (bản ghi trong bảng public.nguoi_dung)
 class NguoiDung {
-  final int ma;                // PK int
-  final String? userId;        // uuid từ auth.users
-  final String tenNguoiDung;   // unique
-  final String? hoVaTen;
+  final String uid; // PK uuid
+  final String? authUid; // uuid từ auth.users
+  final String hoVaTen;
   final String? email;
   final String? soDienThoai;
   final String? diaChi;
-  final int vaiTroId;
+  final String vaiTroUid;
+  final bool daKichHoat;
 
   NguoiDung({
-    required this.ma,
-    required this.tenNguoiDung,
-    required this.vaiTroId,
-    this.userId,
-    this.hoVaTen,
+    required this.uid,
+    required this.hoVaTen,
+    required this.vaiTroUid,
+    this.authUid,
     this.email,
     this.soDienThoai,
     this.diaChi,
+    this.daKichHoat = true,
   });
 
   factory NguoiDung.fromJson(Map<String, dynamic> j) => NguoiDung(
-    ma: j['ma'] as int,
-    userId: j['user_id'] as String?,
-    tenNguoiDung: j['ten_nguoi_dung'] as String,
-    hoVaTen: j['ho_va_ten'] as String?,
-    email: j['email'] as String?,
-    soDienThoai: j['so_dien_thoai'] as String?,
-    diaChi: j['dia_chi'] as String?,
-    vaiTroId: j['vai_tro_id'] as int,
-  );
+        uid: j['uid'] as String,
+        authUid: j['auth_uid'] as String?,
+        hoVaTen: j['ho_va_ten'] as String,
+        email: j['email'] as String?,
+        soDienThoai: j['so_dien_thoai'] as String?,
+        diaChi: j['dia_chi'] as String?,
+        vaiTroUid: j['vai_tro_uid'] as String,
+        daKichHoat: j['da_kich_hoat'] as bool? ?? true,
+      );
 }
 
 class SupabaseAuthService {
@@ -42,9 +42,8 @@ class SupabaseAuthService {
   Future<AuthResponse> signUp({
     required String email,
     required String password,
-    required String tenNguoiDung, // unique theo schema
     required String hoVaTen,
-    required int vaiTroId,        // tham chiếu public.vai_tro(id)
+    required String vaiTroUid, // tham chiếu public.vai_tro(uid)
     String? soDienThoai,
     String? diaChi,
     bool requireEmailConfirmation = false,
@@ -56,8 +55,7 @@ class SupabaseAuthService {
       // metadata nếu muốn (không bắt buộc)
       data: {
         'full_name': hoVaTen,
-        'username': tenNguoiDung,
-        'role_id': vaiTroId,
+        'role_uid': vaiTroUid,
       },
       emailRedirectTo: requireEmailConfirmation ? null : null,
     );
@@ -70,14 +68,12 @@ class SupabaseAuthService {
     final user = res.user;
     if (user != null) {
       await ensureNguoiDungRow(
-        userId: user.id,
-        tenNguoiDung: tenNguoiDung,
+        authUid: user.id,
         hoVaTen: hoVaTen,
         email: email,
         soDienThoai: soDienThoai,
         diaChi: diaChi,
-        vaiTroId: vaiTroId,
-        matKhauMaHoaPlaceholder: 'supabase_managed', // placeholder
+        vaiTroUid: vaiTroUid,
       );
     }
     return res;
@@ -97,46 +93,41 @@ class SupabaseAuthService {
   /// ========== NGƯỜI DÙNG (public.nguoi_dung) ==========
   /// Tạo/đồng bộ row cho user hiện tại (id từ auth.users)
   Future<void> ensureNguoiDungRow({
-    required String userId,
-    required String tenNguoiDung,
+    required String authUid,
     required String hoVaTen,
     required String email,
-    required int vaiTroId,
+    required String vaiTroUid,
     String? soDienThoai,
     String? diaChi,
-    String matKhauMaHoaPlaceholder = 'supabase_managed',
   }) async {
     // Kiểm tra đã có row nào cho userId chưa
     final exist = await supa
         .from('nguoi_dung')
-        .select('ma')
-        .eq('user_id', userId)
+        .select('uid')
+        .eq('auth_uid', authUid)
         .maybeSingle();
 
     if (exist != null) {
       // update nhẹ các trường có thể đổi
       await supa.from('nguoi_dung').update({
-        'ten_nguoi_dung': tenNguoiDung,
         'ho_va_ten': hoVaTen,
         'email': email,
         'so_dien_thoai': soDienThoai,
         'dia_chi': diaChi,
-        'vai_tro_id': vaiTroId,
+        'vai_tro_uid': vaiTroUid,
         'thoi_gian_cap_nhat': DateTime.now().toIso8601String(),
-      }).eq('ma', exist['ma']);
+      }).eq('uid', exist['uid']);
       return;
     }
 
     // insert mới
     await supa.from('nguoi_dung').insert({
-      'user_id': userId,
-      'ten_nguoi_dung': tenNguoiDung,
-      'mat_khau_ma_hoa': matKhauMaHoaPlaceholder, // do cột đang NOT NULL
+      'auth_uid': authUid,
       'ho_va_ten': hoVaTen,
       'email': email,
       'so_dien_thoai': soDienThoai,
       'dia_chi': diaChi,
-      'vai_tro_id': vaiTroId,
+      'vai_tro_uid': vaiTroUid,
       'da_kich_hoat': true,
     });
   }
@@ -148,7 +139,7 @@ class SupabaseAuthService {
     final row = await supa
         .from('nguoi_dung')
         .select('*')
-        .eq('user_id', uid)
+        .eq('auth_uid', uid)
         .maybeSingle();
     if (row == null) return null;
     return NguoiDung.fromJson(row);
@@ -156,27 +147,25 @@ class SupabaseAuthService {
 
   /// Cập nhật hồ sơ người dùng (own row)
   Future<void> updateMyNguoiDung({
-    String? tenNguoiDung,
     String? hoVaTen,
     String? soDienThoai,
     String? diaChi,
-    int? vaiTroId,
+    String? vaiTroUid,
   }) async {
     final uid = currentUser?.id;
     if (uid == null) throw Exception('Chưa đăng nhập');
     final data = <String, dynamic>{
-      if (tenNguoiDung != null) 'ten_nguoi_dung': tenNguoiDung,
       if (hoVaTen != null) 'ho_va_ten': hoVaTen,
       if (soDienThoai != null) 'so_dien_thoai': soDienThoai,
       if (diaChi != null) 'dia_chi': diaChi,
-      if (vaiTroId != null) 'vai_tro_id': vaiTroId,
+      if (vaiTroUid != null) 'vai_tro_uid': vaiTroUid,
       'thoi_gian_cap_nhat': DateTime.now().toIso8601String(),
     };
-    await supa.from('nguoi_dung').update(data).eq('user_id', uid);
+    await supa.from('nguoi_dung').update(data).eq('auth_uid', uid);
   }
 
   /// Lấy danh sách vai trò để hiển thị Dropdown khi đăng ký
   Future<List<Map<String, dynamic>>> fetchRoles() async {
-    return await supa.from('vai_tro').select('*').order('id');
+    return await supa.from('vai_tro').select('*').order('ten');
   }
 }


### PR DESCRIPTION
## Summary
- fetch the default `hoc_vien` role uid from Supabase before inserting new `nguoi_dung` records
- store new sign-up users with `auth_uid`/`vai_tro_uid` fields that match the updated database schema
- update the shared Supabase auth service model and helpers to work with uuid-based role and user identifiers

## Testing
- flutter test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68e2c691cdb0832a98cf2504f8a7c982